### PR TITLE
Replace realsearch.cc with nostr.band

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Outside of nostr itself, you find the community on:
 - [nostr on YouTube](https://www.youtube.com/results?search_query=nostr+protocol)
 - [vanilla-js-nostr](https://github.com/supertestnet/vanilla-js-nostr)![stars](https://img.shields.io/github/stars/supertestnet/vanilla-js-nostr.svg?style=social) - a demo of posting and viewing a feed in nostr using vanilla javascript
 - [nostr playground in Ruby](https://github.com/dtonon/nostr-ruby-playground)![stars](https://img.shields.io/github/stars/dtonon/nostr-ruby-playground.svg?style=social)
-- [search posts by keyword](https://realsearch.cc) - posts from major relays indexed and searchable in real-time
+- [search posts/profiles by keyword](https://nostr.band) - posts from major relays indexed and searchable in real-time
 - [nostr.build](https://nostr.build/) - nostr image uploader
 - [wellorder nostr datasets](https://wiki.wellorder.net/wiki/nostr-datasets/) - Public standardized nostr datasets for benchmarking, data science, or other analysis.  
 - [Nostrovia Podcast](https://nostrovia.org/) - A Nostr podcast covering all the new projects, all the new cool stuff, all the new NIPs. It’s all here. Once a week. Listen to it.


### PR DESCRIPTION
Nostr search feature is moved from realsearch.cc to a dedicated website nostr.band