### PR TITLE
Added Sovereign Stack to Tools section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ of the public instances.
 - [nostr-rs-relay](https://sr.ht/~gheartsfield/nostr-rs-relay/)  - a minimalistic relay written in Rust that saves data on SQLite
 - [Relayer Basic](https://github.com/fiatjaf/relayer/tree/master/basic) - a simple relay based on _relayer_ backed by Postgres
 - [nodestr](https://github.com/Dolu89/nodestr-relay)![stars](https://img.shields.io/github/stars/Dolu89/nodestr-relay.svg?style=social) - a Node.js implementation
+- [sovereign-stack](https://www.sovereign-stack.org) - a tool that helps you deploy nostr relays and create self-hosted (bitcoin-only) Value4Value websites.
 - [expensive relay](https://github.com/fiatjaf/expensive-relay)![stars](https://img.shields.io/github/stars/fiatjaf/expensive-relay.svg?style=social)- a relay that requires payment for registration
 - [me.untethr.nostr-relay](https://github.com/atdixon/me.untethr.nostr-relay)![stars](https://img.shields.io/github/stars/atdixon/me.untethr.nostr-relay.svg?style=social) - a relay written in Clojure
 - [Minds Nostr Relay](https://gitlab.com/minds/infrastructure/nostr-relay) - a relay for [Minds](https://www.minds.com), an open-source social network


### PR DESCRIPTION
Visit https://www.sovereign-stack.org for more details. The git repo for the project can be found at https://git.sovereign-stack.org/ss/sovereign-stack