### PR TITLE
Update nostr-react link

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ them:
 - [NNostr.Client](https://github.com/Kukks/NNostr)![stars](https://img.shields.io/github/stars/Kukks/NNostr.svg?style=social) - a C# Nostr library for use by clients
 - [nostr-tools](https://github.com/fiatjaf/nostr-tools)![stars](https://img.shields.io/github/stars/fiatjaf/nostr-tools.svg?style=social) - a JavaScript client that abstracts the relay management code for use by clients
 - [nostr-relaypool-ts](https://github.com/adamritter/nostr-relaypool-ts)![stars](https://img.shields.io/github/stars/adamritter/nostr-relaypool-ts.svg?style=social) - a TypeScript relay pool library on top of nostr-tools that simplifies handling subscriptions to multiple servers
-- [nostr-react](https://github.com/t4t5/nostr-react)![stars](https://img.shields.io/github/stars/nostrgg/nostrgg-react.svg?style=social) - React Hooks for Nostr
+- [nostr-react](https://github.com/t4t5/nostr-react)![stars](https://img.shields.io/github/stars/t4t5/nostr-react.svg?style=social) - React Hooks for Nostr
 - [go-nostr](https://github.com/fiatjaf/go-nostr)![stars](https://img.shields.io/github/stars/fiatjaf/go-nostr.svg?style=social) - a Go library that implements relay management, plus event encoding and signing utils
 - [nostr_rust](https://github.com/0xtlt/nostr_rust)![stars](https://img.shields.io/github/stars/0xtlt/nostr_rust.svg?style=social) - Functional Rust implementation of the nostr protocol
 - [nostr-js](https://github.com/jb55/nostr-js)![stars](https://img.shields.io/github/stars/jb55/nostr-js.svg?style=social) - a javascript implementation of the nostr protocol

--- a/README.md
+++ b/README.md
@@ -104,8 +104,7 @@ them:
 - [NNostr.Client](https://github.com/Kukks/NNostr)![stars](https://img.shields.io/github/stars/Kukks/NNostr.svg?style=social) - a C# Nostr library for use by clients
 - [nostr-tools](https://github.com/fiatjaf/nostr-tools)![stars](https://img.shields.io/github/stars/fiatjaf/nostr-tools.svg?style=social) - a JavaScript client that abstracts the relay management code for use by clients
 - [nostr-relaypool-ts](https://github.com/adamritter/nostr-relaypool-ts)![stars](https://img.shields.io/github/stars/adamritter/nostr-relaypool-ts.svg?style=social) - a TypeScript relay pool library on top of nostr-tools that simplifies handling subscriptions to multiple servers
-- [nostrgg/client](https://github.com/nostrgg/nostrgg-client)![stars](https://img.shields.io/github/stars/nostrgg/nostrgg-client.svg?style=social) - a TypeScript library for the client that handles the hard stuff
-- [nostrgg/react](https://github.com/nostrgg/nostrgg-react)![stars](https://img.shields.io/github/stars/nostrgg/nostrgg-react.svg?style=social) - React Hooks for Nostr
+- [nostr-react](https://github.com/t4t5/nostr-react)![stars](https://img.shields.io/github/stars/nostrgg/nostrgg-react.svg?style=social) - React Hooks for Nostr
 - [go-nostr](https://github.com/fiatjaf/go-nostr)![stars](https://img.shields.io/github/stars/fiatjaf/go-nostr.svg?style=social) - a Go library that implements relay management, plus event encoding and signing utils
 - [nostr_rust](https://github.com/0xtlt/nostr_rust)![stars](https://img.shields.io/github/stars/0xtlt/nostr_rust.svg?style=social) - Functional Rust implementation of the nostr protocol
 - [nostr-js](https://github.com/jb55/nostr-js)![stars](https://img.shields.io/github/stars/jb55/nostr-js.svg?style=social) - a javascript implementation of the nostr protocol


### PR DESCRIPTION
The name of my [nostr-react](https://github.com/t4t5/nostr-react) library has been updated, and I've deprecated [nostrgg-client](https://github.com/nostrgg/nostrgg-client) in favour of [nostr-tools](https://github.com/nbd-wtf/nostr-tools). Updating the list so that it's up-to-date for new builders! 👍