### PR TITLE
Remove qualifier in nostr.watch description

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ them:
 
 - [nostr relay registry](https://nostr-registry.netlify.app/) - real-time checking of status of some known relays
 - [nostr.info](https://nostr.info/) - real-time checking of status of some known relays
-- [nostr.watch](https://nostr.watch) - real-time checking of status of some known relays with advanced checks.
+- [nostr.watch](https://nostr.watch) - real-time checking of status of some known relays
 
 ## Clients
 


### PR DESCRIPTION
When that descripttion was drafted it made sense, it no longer does as peers no longer include a qualifier in their description