### PR TITLE
Replace the link for "tinkering with nostr without any client"

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ created by [@fiatjaf](https://github.com/fiatjaf).
 - [UseNostr](https://usenostr.org) - A small guide for anyone who wants to learn more about how nostr works and what it can do.
 - [nostr.how](https://nostr.how) - Quick-start to onboard desktop users with Alby & Astral
 - [nostr.guide](https://nostr.guide) - A guide to all things nostr
-- [tinkering with nostr without any client](https://github.com/p2w34/blog/blob/master/2023-02-11-tinkering-with-the-nostr-protocol/tinkering-with-the-nostr-protocol.md)
+- [tinkering with nostr without any client](https://medium.com/@p2w34/tinkering-with-the-nostr-protocol-will-it-take-twitter-over-74c4bf0fea66)
 
 ## Relays
 


### PR DESCRIPTION
Replaced the link with the one from medium.com. The reason is that one can see comments there.