### PR TITLE
Add nostrss

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,8 @@ them:
 - [Mostr](https://gitlab.com/soapbox-pub/mostr)![stars](https://img.shields.io/gitlab/stars/soapbox-pub/mostr.svg?style=social) - a bridge between Nostr and the Fediverse (Mastodon, ActivityPub, etc.)
 - [rsslay](https://github.com/piraces/rsslay)![stars](https://img.shields.io/github/stars/piraces/rsslay.svg?style=social) - fork of the rsslay by @fiatjaf. a bridge that puts RSS feeds into Nostr optimized, more funcionalities and UI improvements. Live at [rsslay.nostr.moe](https://rsslay.nostr.moe/)
 - [smtp nostr gateway ](https://github.com/Cameri/smtp-nostr-gateway)![stars](https://img.shields.io/github/stars/Cameri/smtp-nostr-gateway.svg?style=social) - a bridge that forwards emails to pubkeys as encrypted direct messages
-
+- [nostrss](https://github.com/Asone/nostrss)![stars](https://img.shields.io/github/stars/Asone/nostrss.svg?style=social) - A flexible and lightweight application to broadcast  RSS feeds on Nostr
+- [rsslay.nostr.moe](https://rsslay.nostr.moe/)
 Sure, here's the list sorted alphabetically while maintaining the markdown syntax:
 
 matrix-nostr-bridgestars - a simple Matrix-to-Nostr or Nostr-to-Matrix bridge


### PR DESCRIPTION
Hi, i'd like to submit the [Nostrss](https://github.com/Asone/nostrss)  tool i built to the list. 

Hoping it will fit in the list. 

Please feel free to tell me if there's something missing or tell me why it wouldn't fit here if that was the case. 

Side-note : the repo also provides a list of npubs of feeds already broadcasted through my personal instance. Should that go somewhere in the curation list too ? 

Many thanks ! 

Kind regards, 

Asone