### PR TITLE
add bitwarden-feature-request in awesome-nostr?

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,7 +414,7 @@ Outside of nostr itself, you find the community on:
 - [vanilla-js-nostr](https://github.com/supertestnet/vanilla-js-nostr)![stars](https://img.shields.io/github/stars/supertestnet/vanilla-js-nostr.svg?style=social) - a demo of posting and viewing a feed in nostr using vanilla javascript
 - [Zaplife](https://zaplife.lol) - Real-time feed for nostr zaps. The best tool to shut up the "lightning doesn't work" people.
 - [wellorder nostr datasets](https://wiki.wellorder.net/wiki/nostr-datasets/) - Public standardized nostr datasets for benchmarking, data science, or other analysis.
-
+- [Private key management for nostr accounts](https://community.bitwarden.com/t/private-key-management-for-nostr-accounts/51768): Add nostr protocol support in Bitwarden to manage keys in different applications and services
 
 Data for this list is contributed by the community and curated by [@aaaljaz](https://twitter.com/aaaljaz) ( npub1aljazgxlpnpfp7n5sunlk3dvfp72456x6nezjw4sd850q879rxqsthg9jp)
 


### PR DESCRIPTION
Hi awesome-nostr @aljazceru !

I would like to know if it would be possible to include this [link](https://community.bitwarden.com/t/private-key-management-for-nostr-accounts/51768) in this repository. Recently, I saw in the Bitwarden community, a user post a feature request to support the nostr protocol in Bitwarden.

Maybe I think this is an important step towards increasing the extensibility of the nostr network protocol. And so for that, I'm requesting that initially here. Because If the nostr community uses the Bitwarden password manager, it would be interesting to follow this feature. And see if nostr could somehow complement the Bitwarden password manager.

But the Bitwarden community has not yet accepted the request and it is open. This order is open and some votes are needed.

*I made this disclaimer initially because I don't know whether or not it can be accepted here.* 

Maybe part of the Bitwarden and nostr community are together for something innovative in the technological sense of the word and excitement in the sense of making things more convenient for anyone who logs into websites.

It is very common for some open source projects to have common values: "privacy", "security". That's why I created this initial pull-request.
