### PR TITLE
Add OneKey to NIP-07 Supported browser extensions list

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,6 +435,7 @@ Allow you to sign Nostr events on web-apps without having to give them your keys
 - [Nostrmo](https://github.com/haorendashu/nostrmo_faq#download) - A nostr client.
 - [Nostore on GitHub](https://github.com/ursuscamp/nostore)![stars](https://img.shields.io/github/stars/ursuscamp/nostore.svg?style=social) - Nostr Signer Extension for iOS/macOS Safari ([Nostore on Mac App Store](https://apps.apple.com/us/app/nostore/id1666553677))
 - [nostr-keyx](https://github.com/susumuota/nostr-keyx)![stars](https://img.shields.io/github/stars/susumuota/nostr-keyx.svg?style=social) - A NIP-07 browser extension that uses the OS's keychain or YubiKey to protect your private keys.
+- [OneKey](https://onekey.so)![stars](https://img.shields.io/github/stars/onekeyhq/app-monorepo.svg?style=social) - Open-source crypto wallet with nosrt support.
 - [Spring Browser](https://spring.site) - Nostr-focused browser app for Android.
 - [TokenPocket](https://github.com/TP-Lab/TokenPocket)![stars](https://img.shields.io/github/stars/TP-Lab/TokenPocket.svg?style=social) - Multi wallet browser extension with nostr support. https://tokenpocket.pro
 - [wen](https://github.com/fiatjaf/wen)![stars](https://img.shields.io/github/stars/fiatjaf/wen.svg?style=social) - browser extension for website enhancer with nostr


### PR DESCRIPTION
Adding OneKey to the NIP-07 List.

I'm excited to share with everyone that OneKey now fully supports NIP07.

[OneKey](https://onekey.so/) is a completely open-source wallet. Here is our PR and documentation for the work we've done for Nostr.

PR: https://github.com/OneKeyHQ/app-monorepo/pull/3864
Document: https://developer.onekey.so/connect-to-software/webapp-connect-onekey/nostr/guide