### PR TITLE
docs: add nostr-spring-boot-starter to libraries section

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ Websites with lists of relays and their performance/health:
     * Kotlin: [`io.github.rust-nostr:nostr-sdk`](https://central.sonatype.com/artifact/io.github.rust-nostr/nostr-sdk/)
     * Swift: https://github.com/rust-nostr/nostr-sdk-swift
     * Python: https://pypi.org/project/nostr-sdk
+- [nostr-spring-boot-starter](https://github.com/theborakompanioni/nostr-spring-boot-starter)![stars](https://img.shields.io/github/stars/theborakompanioni/nostr-spring-boot-starter.svg?style=social) - Spring boot starter projects for building Nostr applications.
 
 
 ## Bridges and Gateways


### PR DESCRIPTION
See https://github.com/theborakompanioni/nostr-spring-boot-starter

> Spring boot starter projects for building [Nostr](https://github.com/nostr-protocol/nostr) applications. Whether you're building your own client or custom relay software, this framework provides most of what you need to write scalable and efficient solutions effortlessly.