### PR TITLE
Add NIP-29 Group Chat Relay

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ of the public instances.
 - [Nerostr](https://codeberg.org/pluja/nerostr) - A Nostr expensive relay paid with Monero and written in Go
 - [Nostr client and relay](https://github.com/pedro-vicente/nostr_client_relay)![stars](https://img.shields.io/github/stars/pedro-vicente/nostr_client_relay.svg?style=social) -  C++ engine that allows to build Nostr applications for command line, desktop or web.
 - [Nosflare](https://github.com/Spl0itable/nosflare)![stars](https://img.shields.io/github/stars/Spl0itable/nosflare.svg?style=social) -  a serverless Nostr relay purpose-built for [Cloudflare Workers](https://workers.cloudflare.com/) and the [Cloudflare KV](https://www.cloudflare.com/products/workers-kv/) store.
+- [NIP-29 Group Chat Relay](https://github.com/max21dev/groups-relay)![stars](https://img.shields.io/github/stars/max21dev/groups-relay.svg?style=social) - NIP-29 Group Chat Relay based on fiatjaf's [Relay29](https://github.com/fiatjaf/relay29) and [Khatru](https://github.com/fiatjaf/khatru).
+  - Live instance: [wss://relay.groups.nip29.com](https://relay.groups.nip29.com)
 
 ### Relay lists 
 Websites with lists of relays and their performance/health:


### PR DESCRIPTION
added Github repo and live instance address for NIP-29 Group Chat Relay.