### PR TITLE
Add metadata_updater tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,6 +451,7 @@ Websites with lists of relays and their performance/health:
 - [Chief](https://github.com/0xtrr/chief) - A Strfry write policy plugin that provides blacklists for public keys, event kinds and words/sentences.
 - [nostr-badges](https://github.com/neilck/nostr-badges)![stars](https://img.shields.io/github/stars/neilck/nostr-badges.svg?style=social) - Nostr badge microservice for managing self-awarded badges. Live at [app.akaprofiles.com](https://app.akaprofiles.com)
 - [nostpy-cli](https://github.com/UTXOnly/nostpy-cli)![stars](https://img.shields.io/github/stars/UTXOnly/nostpy-cli.svg?style=social) - A Python command line nostr client/tool for relay development
+- [metadata_updater](https://github.com/UTXOnly/metadata_updater)![stars](https://img.shields.io/github/stars/UTXOnly/metadata_updater.svg?style=social) - Scans all known online nostr relays for stale kind 0 metadata notes, rebroadcasts latest verified note
 
 ## NIP-05 identity services
 


### PR DESCRIPTION
Adds repo for metadata updater tool which scans all known online nostr relays for stale kind 0 metadata notes, rebroadcasts latest verified note to relays with stale metadata