### PR TITLE
Add MULTIPASS to Web clients list

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ nostr.net services [start.nostr.net](https://start.nostr.net) || [relay.nostr.ne
 - [primal.net](https://primal.net/)
 - [coracle.social](https://coracle.social/)
 - [YakiHonne](https://yakihonne.com)
-
+* [MULTIPASS](https://qo-op.com) - A sovereign digital identity packaged as a portable, printable HTML "Zine" that generates your Nostr keys.
+* 
 ### Other
 - [Zapstore](https://zapstore.dev/) - Web of trust based app store 
 - [Hivetalk](https://honey.hivetalk.org/) - Nostr + Lightning Video Conferencing


### PR DESCRIPTION
Hello!

I'd like to suggest adding **MULTIPASS** to the `awesome-nostr` list under the Web clients section.

MULTIPASS isn't a traditional Nostr client, but rather a **sovereign identity system** that empowers the user by generating their Nostr keys within a self-contained, portable, and printable HTML file, formatted as a "Zine".
* [example](https://ipfs.copylaradio.com/ipfs/QmbBhz6FA68Xy5RY3WWtNiQryyggSV9R8WAa1vvsH3dgtu) 

**Key features:**

*   **Sovereign Key Management:** The user has full control over their keys, which are generated and stored locally within the HTML file.
*   **Unique Format:** The "Zine" format makes a digital identity tangible and easy to back up offline.
*   **Ecosystem Gateway:** It serves as an entry point to the UPlanet ecosystem, which uses Nostr for its communication layer (e.g., via the Coracle client) and integrates it with a decentralized geo-spatial IPFS framework and the Ğ1 Monnaie Libre's Web of Trust.

I believe it's a valuable addition to the list as it represents a unique and innovative approach to Nostr identity and key handling.

I've placed it under the "Web" section as its primary interface is a local HTML file opened in a browser.

Thank you for maintaining this great resource!
