### PR TITLE
fix: restore page-level scroll for main content area

### DIFF
--- a/script.js
+++ b/script.js
@@ -1086,7 +1086,10 @@ function displaySection(sectionName, sections) {
         }
     });
 
-    window.scrollTo(0, 0);
+    // Scroll document to top (works across all browsers)
+    window.scrollTo({ top: 0, left: 0, behavior: 'instant' });
+    document.documentElement.scrollTop = 0;
+    document.body.scrollTop = 0;
 }
 
 function applyColorTheme(themeName) {

--- a/styles.css
+++ b/styles.css
@@ -168,10 +168,7 @@ body {
     padding-top: 80px; /* Increased padding-top to account for fixed nav */
     flex: 1;
     min-height: 100vh;
-    overflow: auto;
     margin-top: 0;
-    -webkit-overflow-scrolling: touch;
-    overscroll-behavior: contain;
 }
 
 .content-header {
@@ -505,45 +502,45 @@ body {
     color: #f1c40f;
 }
 
-/* Main content scrollbar styles */
-.main-content::-webkit-scrollbar {
+/* Main content scrollbar styles (targets the document scroll) */
+html::-webkit-scrollbar {
     width: 8px;
 }
 
-.main-content::-webkit-scrollbar-track {
+html::-webkit-scrollbar-track {
     background: var(--background-color);
 }
 
-.main-content::-webkit-scrollbar-thumb {
+html::-webkit-scrollbar-thumb {
     background: var(--primary-color);
     opacity: 0.5;
     border-radius: 4px;
     transition: background 0.2s ease;
 }
 
-.main-content::-webkit-scrollbar-thumb:hover {
+html::-webkit-scrollbar-thumb:hover {
     background: var(--hover-color);
 }
 
 /* Firefox main content scrollbar styles */
-.main-content {
+html {
     scrollbar-width: thin;
     scrollbar-color: var(--primary-color) var(--background-color);
 }
 
 /* Dark theme scrollbar adjustments */
 [data-theme="dark"] .sidebar::-webkit-scrollbar-track,
-[data-theme="dark"] .main-content::-webkit-scrollbar-track {
+[data-theme="dark"] html::-webkit-scrollbar-track {
     background: var(--sidebar-background);
 }
 
 [data-theme="dark"] .sidebar::-webkit-scrollbar-thumb,
-[data-theme="dark"] .main-content::-webkit-scrollbar-thumb {
+[data-theme="dark"] html::-webkit-scrollbar-thumb {
     background: rgba(110, 84, 148, 0.6);
 }
 
 [data-theme="dark"] .sidebar::-webkit-scrollbar-thumb:hover,
-[data-theme="dark"] .main-content::-webkit-scrollbar-thumb:hover {
+[data-theme="dark"] html::-webkit-scrollbar-thumb:hover {
     background: rgba(110, 84, 148, 0.8);
 }
 


### PR DESCRIPTION
## Problem

`.main-content` had three CSS properties that together caused scrolling to break on mobile browsers (iOS Safari, Android Chrome):

```css
.main-content {
    overflow: auto;
    overscroll-behavior: contain;
    -webkit-overflow-scrolling: touch;
}
```

These cause the browser to treat `.main-content` as an internal scroll container. Since `.main-content` grows freely with its content (no fixed height — only `min-height: 100vh`), its internal overflow never triggers. Scroll events get captured by the element, find no overflow to scroll, and die there — leaving the page stuck.

On desktop Chrome/Firefox this was masked because mouse-wheel events propagate differently. On mobile touch devices, `overscroll-behavior: contain` + `overflow: auto` are enough to trap all scroll intent inside `.main-content` with nowhere to go.

## Fix

- Remove `overflow: auto`, `overscroll-behavior: contain`, and `-webkit-overflow-scrolling: touch` from `.main-content`
- Page-level scroll (document/html) handles all main content scrolling — this is the correct model given `.main-content` is not a fixed-height container
- The sidebar correctly keeps its `overflow-y: auto` since it IS fixed-height and needs internal scroll
- Move webkit/Firefox scrollbar styling from `.main-content` to `html` (the actual scroll container)
- Improve `displaySection()` scroll-to-top with three reset methods for full cross-browser compatibility

## Tested

Verified with headless Chromium: all 31 sections render correctly, 70+ cards in the Relays section scroll properly, sidebar navigation works.