### PR TITLE
Add Nostrian Conquest to Games on Nostr

### DIFF
--- a/README.md
+++ b/README.md
@@ -846,6 +846,7 @@ Endpoints (services or apps that expose a LN wallet via NWC)
 
 - [NostrDice](https://github.com/NostrDice/nostrdice)![stars](https://img.shields.io/github/stars/NostrDice/nostrdice) - NostrDice is a provably fair betting game combining the power of Lightning and Nostr.
   - Live: [app.nostrdice.com](https://app.nostrdice.com)
+- [Nostrian Conquest](https://nostrian-conquest.com) - A turn-based multiplayer space strategy game inspired by classic BBS door games, rebuilt in Rust and powered by Nostr for decentralized play.
 - [Words with Zaps](https://www.wordswithzaps.top) - A two-player crossword-style word game with bonus features designed around Lightning and Nostr.
   
 ## Communities


### PR DESCRIPTION
## Summary
- add Nostrian Conquest to the Games on Nostr section
- link to the public project site

## Description
Nostrian Conquest is a turn-based multiplayer space strategy game inspired by classic BBS door games, rebuilt in Rust and powered by Nostr for decentralized play.