### PR TITLE
Add Skatting - serverless 2D ticket estimation using Nostr signaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ Websites with lists of relays and their performance/health:
 - [Shipyard](https://shipyard.pub/) - Write, schedule, and boost your notes.
 - [shockwallet](https://github.com/shocknet/wallet2)![stars](https://img.shields.io/github/stars/shocknet/wallet2.svg?style=social) - A Lightning wallet that uses nostr and lnurl to connect to nodes
 - [SIGit](https://sigit.io) - An open-source, self-hostable solution for secure document signing and verification.
+- [Skatting](https://github.com/WimYedema/skatting)![stars](https://img.shields.io/github/stars/WimYedema/skatting.svg?style=social) - Serverless 2D ticket estimation for agile teams. Express effort + certainty by dragging a log-normal blob on a 2D canvas. P2P via WebRTC (Nostr + MQTT signaling) with AES-256-GCM encrypted Nostr relay fallback. No signup, no server.
 - [Snort](https://github.com/v0l/snort)![stars](https://img.shields.io/github/stars/v0l/snort.svg?style=social) - Nostr UI written in react
   - [snort.social](https://snort.social)
 - [Spring Browser](https://spring.site) - Nostr-focused browser app for Android.


### PR DESCRIPTION
Skatting is an open-source, serverless team estimation tool that uses Nostr in two ways:

1. **WebRTC signaling** via Trystero (alongside MQTT) to establish direct peer connections
2. **Encrypted fallback relay** — AES-256-GCM encrypted ephemeral events (kind 25078) for clients where WebRTC is blocked by corporate firewalls

It also uses replaceable events (kind 30078/30079) to persist room state across sessions.

Live app: https://wimyedema.github.io/skatting/
Source: https://github.com/WimYedema/skatting
License: MIT