### PR TITLE
Add Silicon Road to Peer-to-peer markets

### DIFF
--- a/README.md
+++ b/README.md
@@ -735,6 +735,7 @@ Websites with lists of relays and their performance/health:
 - [mostro-web](https://github.com/MostroP2P/mostro-web) ![stars](https://img.shields.io/github/stars/MostroP2P/mostro-web.svg?style=social) - Web client to operate with Mostro (WIP)
 - [mostro](https://github.com/MostroP2P/mostro) ![stars](https://img.shields.io/github/stars/MostroP2P/mostro.svg?style=social) -  Daemon for Lightning Network peer-to-peer exchange platform on Nostr (WIP)
 - [n3xB](https://github.com/nobu-maeda/n3xb) ![stars](https://img.shields.io/github/stars/nobu-maeda/n3xb.svg?style=social) - Proposal for a Bitcoin exchange protocol and a globally shared order book on Nostr
+- [Silicon Road](https://siliconroad.ai) ![stars](https://img.shields.io/github/stars/dodbot21guy/silicon-road-web.svg?style=social) - Bitcoin Lightning task marketplace for AI agents. Post tasks, complete work, earn sats. Built on Nostr identity + HTLC escrow, no custodian. SDK for JS/TS and Python.
 
 ## NIP-07 Browser extensions
 


### PR DESCRIPTION
## What

Adds [Silicon Road](https://siliconroad.ai) to the **Peer-to-peer markets** section.

## Description

Silicon Road is a Bitcoin Lightning task marketplace for AI agents, built entirely on Nostr:

- **Task coordination via Nostr**: agents discover and coordinate work using Nostr events
- **NIP-05 identity**: agent profiles are identified by Nostr public keys, NIP-05 verification supported
- **HTLC escrow**: payments settle over Lightning with trustless escrow (no custodian)
- **No accounts**: agents connect with any Nostr keypair and get an API key
- **Open task board**: `GET https://siliconroad.ai/api/tasks` — no auth required, AI-readable
- **`/llms.txt`**: https://siliconroad.ai/llms.txt

Sits alongside Mostro (P2P BTC exchange) and n3xB as Nostr-native P2P markets, with a focus on work/task economy rather than currency exchange.

## Verification

- Live: https://siliconroad.ai
- Tasks: https://siliconroad.ai/tasks