### PR TITLE
Add NostrBotKit to the list of Nostr tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -666,6 +666,7 @@ Websites with lists of relays and their performance/health:
 - [nostr.json generator](https://github.com/SnowCait/nostr-json-generator)![stars](https://img.shields.io/github/stars/SnowCait/nostr-json-generator.svg?style=social) - Generate NIP-05 nostr.json from NIP-65 or NIP-07
 - [NostrAirTracker](https://github.com/gourcetools/NostrAirTracker)![stars](https://img.shields.io/github/stars/gourcetools/NostrAirTracker.svg?style=social) - Elonjet on Nostr
 - [nostraap](https://github.com/ccs-mz/nostraap) - NostraApp is a decentralized messaging application inspired by WhatsApp, built on the Nostr protocol, with native support for end-to-end encryption, distributed relay networks, and Bitcoin Lightning payments (Zaps)
+- [NostrBotKit](https://codeberg.org/Tuxor/NostrBotKit) - Open-source bot management framework for Nostr, inspired by Telegram's BotFather. Written in Rust.
 - [nostress](https://github.com/4383/nostress)![stars](https://img.shields.io/github/stars/4383/nostress.svg?style=social) - ⚡ Modern Python CLI for Nostr protocol interactions - secure key management, event creation, and relay operations
 - [nostrame](https://github.com/Anderson-Juhasc/nostrame)![stars](https://img.shields.io/github/stars/Anderson-Juhasc/nostrame.svg?style=social) - Nostr Signer and Account Management Extension 
 - [nostrandom.netlify.app](https://nostrandom.netlify.app/) - generate publish-able Nostr event with random keys


### PR DESCRIPTION
Add NostrBotKit — Nostr bot management framework (Rust) NostrBotKit is an open-source bot management framework for Nostr, inspired by Telegram’s BotFather. It allows developers and non-technical users to deploy and manage multiple bots on Nostr without relying on any central infrastructure. Key features:
	•	Multi-bot orchestration via AlphaBot
	•	NIP-17 (Gift Wrap) and NIP-04 DM support
	•	YAML-based configuration with per-bot inheritance
	•	Three-tier permission system (Admin / Private / Public)
	•	Docker/Compose deployment
	•	Blueprint system for non-technical bot deployment (WIP)
	•	Written in Rust using nostr-sdk and Tokio
Repository: https://codeberg.org/Tuxor/NostrBotKit