### PR TITLE
Add Deepmarks to NIP-07 extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -839,6 +839,7 @@ Allow you to sign Nostr events on web-apps without having to give them your keys
 - [Bunker46](https://github.com/dsbaars/bunker46-extension)![stars](https://img.shields.io/github/stars/dsbaars/bunker46-extension.svg?style=social) - NIP-07 remote signer via NIP-46
   - [Chromium extension](https://chromewebstore.google.com/detail/bunker46/hffbfaedhainmpaodhdgepnmmkmpahaa)
   - [Firefox extension](https://addons.mozilla.org/nl/firefox/addon/bunker46/)
+- [Deepmarks](https://deepmarks.org/extension)![stars](https://img.shields.io/github/stars/ostermayer/deepmarks-public.svg?style=social) - Nostr-native bookmarking browser extension with NIP-07 signing for Chrome, Firefox, and Safari.
 - [horse](https://github.com/fiatjaf/horse) - hardware remote nostr event signer with webserial
 - [Keys.Band](https://keys.band) - Multi-key Nostr signing extension for Chrome with a sleak UI/UX. Based on NOS2X.
 - [NIP-07 Signing Extension Tester](https://github.com/neilck/nip07-tester)![stars](https://img.shields.io/github/stars/neilck/nip07-tester.svg?style=social) - This Next.js app tests NIP-07, showing supported functions and raw results for the current signing extension.


### PR DESCRIPTION
Adds Deepmarks as a Nostr-native bookmarking browser extension with NIP-07 signing support for logging into compatible apps.