### PR TITLE
Add TWZRD Agent Intel - MCP server for AI agent wallet trust scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -617,6 +617,7 @@ Websites with lists of relays and their performance/health:
   - [liquiditystr.space](https://liquiditystr.space/) - live instance 
 - [lnpass](https://lnpass.github.io)![stars](https://img.shields.io/github/stars/lnpass/lnpass-web.svg?style=social) - A key manager for Lightning and nostr.
 - [lightning-memory](https://github.com/singularityjason/lightning-memory)![stars](https://img.shields.io/github/stars/singularityjason/lightning-memory.svg?style=social) - Decentralized agent memory for the Lightning economy. Nostr identity, L402 payments, MCP server.
+- [TWZRD Agent Intel](https://intel.twzrd.xyz) - MCP server for AI agent wallet trust scoring on Solana. Verify agent wallet identity before x402 micropayments and zaps. Free tools: `score_agent(wallet)`, `preflight_check(wallet)`. Config: `{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}`
 - [metadata_updater](https://github.com/UTXOnly/metadata_updater)![stars](https://img.shields.io/github/stars/UTXOnly/metadata_updater.svg?style=social) - Scans all known online nostr relays for stale kind 0 metadata notes, rebroadcasts latest verified note
 - [Mutable](https://mutable.top) - A tool for managing, backing up, restoring, and sharing Nostr mute lists.
 - [Mute-o-Scope](https://www.mutable.top/mute-o-scope) - A standalone feature of Mutable that lets users search any npub to see who is publicly muting them.


### PR DESCRIPTION
## Summary

Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) to the **Tools** section.

TWZRD Agent Intel is an MCP server providing on-chain trust scoring for AI agent wallets on Solana. As AI agents increasingly operate on Nostr — executing zaps, interacting with NIP-90 data vending machines, or participating in wallet-gated content — tools to verify agent wallet identity before payments become essential.

**MCP Configuration:**
```json
{"mcpServers": {"twzrd-agent-intel": {"url": "https://intel.twzrd.xyz/mcp"}}}
```

**Free tools:**
- `score_agent(wallet)` — Trust score + on-chain reputation for any Solana wallet
- `preflight_check(wallet)` — Validates agent wallet before payment acceptance

**Paid tool (x402 micropayment):**
- `get_trust_receipt(wallet)` — Verifiable signed trust receipt for agent identity

Relevant for Nostr AI agents and zap automation flows where wallet identity verification matters.