### PR TITLE
Add Vega — cross-platform desktop client (Linux/Windows/macOS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,8 @@ Websites with lists of relays and their performance/health:
   - [u-blog.vercel.app](https://u-blog.vercel.app)
 - [Vector](https://github.com/VectorPrivacy/Vector)![stars](https://img.shields.io/github/stars/VectorPrivacy/Vector.svg?style=social) - A privacy-focused encrypted messenger built on Nostr using NIP-17, with zero metadata leakage. Available for Windows, macOS, Linux, and Android.
   - [vectorapp.io](https://vectorapp.io)
+- [Vega](https://github.com/hoornet/vega)![stars](https://img.shields.io/github/stars/hoornet/vega.svg?style=social) - A cross-platform desktop client for Linux, Windows and macOS (Tauri + React), with first-class long-form writing and reading (NIP-23), zaps via NWC, V4V podcast streaming, web of trust filtering, and an optional built-in relay.
+  - [veganostr.com](https://veganostr.com/)
 - [Votestr](https://votestr.com/)![stars](https://img.shields.io/github/stars/vilm3r/votestr.svg?style=social) - Poll web app with nostr authentication and blind signature unlinkability
 - [Voyage](https://github.com/dluvian/voyage)![stars](https://img.shields.io/github/stars/dluvian/voyage.svg?style=social) - Lightweight Android client with a Reddit-like UI
 - [Wherostr](https://github.com/mapboss/wherostr_social)![stars](https://img.shields.io/github/stars/mapboss/wherostr_social.svg?style=social) - A decentralized geo-social for iOS & Android.

--- a/README.md
+++ b/README.md
@@ -399,7 +399,7 @@ Websites with lists of relays and their performance/health:
   - [u-blog.vercel.app](https://u-blog.vercel.app)
 - [Vector](https://github.com/VectorPrivacy/Vector)![stars](https://img.shields.io/github/stars/VectorPrivacy/Vector.svg?style=social) - A privacy-focused encrypted messenger built on Nostr using NIP-17, with zero metadata leakage. Available for Windows, macOS, Linux, and Android.
   - [vectorapp.io](https://vectorapp.io)
-- [Vega](https://github.com/hoornet/vega)![stars](https://img.shields.io/github/stars/hoornet/vega.svg?style=social) - A cross-platform desktop client for Linux, Windows and macOS (Tauri + React), with first-class long-form writing and reading (NIP-23), zaps via NWC, V4V podcast streaming, web of trust filtering, and an optional built-in relay.
+- [Vega](https://github.com/hoornet/vega)![stars](https://img.shields.io/github/stars/hoornet/vega.svg?style=social) - A client for Linux, Windows and macOS (Tauri + React), with long-form writing and reading (NIP-23), V4V podcast streaming, WoT filtering and an optional built-in relay.
   - [veganostr.com](https://veganostr.com/)
 - [Votestr](https://votestr.com/)![stars](https://img.shields.io/github/stars/vilm3r/votestr.svg?style=social) - Poll web app with nostr authentication and blind signature unlinkability
 - [Voyage](https://github.com/dluvian/voyage)![stars](https://img.shields.io/github/stars/dluvian/voyage.svg?style=social) - Lightweight Android client with a Reddit-like UI


### PR DESCRIPTION
Adds Vega to Clients → Other, as suggested in #677.

Vega is an MIT-licensed desktop Nostr client (Tauri 2 + React) for Linux, Windows and macOS. Long-form (NIP-23) reading and writing is a first-class feature, alongside zaps (NIP-47/57), V4V podcast streaming, web-of-trust filtering, and an optional built-in relay.

- Repo: https://github.com/hoornet/vega
- Site: https://veganostr.com

Thanks for the nudge to just open a PR.