### PR TITLE
Add blossom-npub-guard to Blossom

### DIFF
--- a/README.md
+++ b/README.md
@@ -982,6 +982,7 @@ Endpoints (services or apps that expose a LN wallet via NWC)
 - [blossy](https://github.com/pippellia-btc/blossy)![stars](https://img.shields.io/github/stars/pippellia-btc/blossy.svg?style=social) - A framework for building fully custom Blossom servers, designed for the best developer experience. Supports all Blossom endpoints and allows developers to express custom business logic on top of a protocol-compliant foundation.
 - [blisk](https://github.com/pippellia-btc/blisk)![stars](https://img.shields.io/github/stars/pippellia-btc/blisk.svg?style=social) - An efficient, scalable, and deduplicated local blob storage that maintains metadata in SQLite. Fully compatible with Blossom, it gives developers a reliable database option for building their own Blossom servers.
 - [blossom servers](https://blossomservers.com/) - List of blossom servers
+- [blossom-npub-guard](https://github.com/SapienLearn/blossom-npub-guard)![stars](https://img.shields.io/github/stars/SapienLearn/blossom-npub-guard.svg?style=social) - Dependency-free TypeScript guard for clients: detects when an npub is the *host* of a Blossom npub-subdomain URL (npub1....blossom.band) so it isn't rewritten into a nostr: mention, which breaks the media URL. Ships tests for the full bug class.
 
 ## Games on Nostr
 


### PR DESCRIPTION
Adds blossom-npub-guard to the Blossom section.

Context: several clients rewrite any bech32 npub they find in text into a nostr: mention. When the npub is actually the subdomain host of a Blossom URL (npub1....blossom.band/<sha256>), that rewrite mangles the URL and the media breaks (root-caused in CodyTseng/jumble#830). This is a tiny, dependency-free TS function (+ vitest cases) any client can drop in to guard the rewrite path.

MIT, AI-built and disclosed in the README, human-supervised. Happy to move it to Libraries instead if you think that's a better home.