### PR TITLE
Add GUPT to Web clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ nostr.net services [start.nostr.net](https://start.nostr.net) || [relay.nostr.ne
 - [coracle.social](https://coracle.social/)
 - [YakiHonne](https://yakihonne.com)
 - [Ditto](https://ditto.pub)
+- [GUPT](https://gupt.app) - Browser-native, serverless encrypted messenger and privacy suite. E2E encrypted chat, P2P WebRTC calls, password vault, and IPFS media storage. No phone number or account required.
 
 ### Other
 - [Zapstore](https://zapstore.dev/) - Web of trust based app store 


### PR DESCRIPTION
Adding GUPT to the Most popular > Web clients section.

GUPT is a browser-native, serverless encrypted messenger and privacy suite built on Nostr. Features E2E encrypted chat, P2P WebRTC voice/video calls, a password vault, and IPFS-based media storage. No phone number, email, or account required.

- Repository: https://github.com/besoeasy/gupt
- Website: https://gupt.app

I am the author/maintainer of this project.