### PR TITLE
Add File Blossom to Web clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ nostr.net services [start.nostr.net](https://start.nostr.net) || [relay.nostr.ne
 - [coracle.social](https://coracle.social/)
 - [YakiHonne](https://yakihonne.com)
 - [Ditto](https://ditto.pub)
+- [File Blossom](https://qyronx.github.io/fileblossom/)
 
 ### Other
 - [Zapstore](https://zapstore.dev/) - Web of trust based app store 


### PR DESCRIPTION
Adding File Blossom to the Most popular > Web clients section.

File Blossom is a browser based,  serverless, encrypted file sharing site and privacy suite built on Nostr and Blossom.
There is no limit about file size, extension name and number of files.

Also File Blossom issues Nostr key automatically when you upload files then deleting files & sharing files all work by links.

Repository: https://github.com/qyronx/fileblossom
Website: https://qyronx.github.io/fileblossom/

<img width="572" height="590" alt="스크린샷 2026-07-29 084654" src="https://github.com/user-attachments/assets/b380a1da-5777-49c6-ae16-723c433c804c" />
<img width="524" height="223" alt="스크린샷 2026-07-29 085107" src="https://github.com/user-attachments/assets/5033db1d-1f40-4698-ae74-81b5cf618585" />
.