### PR TITLE
Add zod-nostr to Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -560,6 +560,7 @@ Websites with lists of relays and their performance/health:
 - [nostr](https://github.com/ClarkQAQ/nostr) - A comprehensive Go library for the Nostr protocol, providing everything needed to build relays, clients, or hybrid applications
 - [nostr-sdk-flutter](https://github.com/rust-nostr/nostr-sdk-flutter)![stars](https://img.shields.io/github/stars/rust-nostr/nostr-sdk-flutter.svg?style=social) - Nostr protocol implementation, Relay, RelayPool, high-level client library, NWC client and more
 - [applesauce](https://github.com/hzrd149/applesauce)![stars](https://img.shields.io/github/stars/hzrd149/applesauce.svg?style=social) - Reactive Nostr framework with utilities for building reactive UIs and event stores.
+- [zod-nostr](https://github.com/akiomik/zod-nostr)![stars](https://img.shields.io/github/stars/akiomik/zod-nostr.svg?style=social) - Zod schemas and codecs for Nostr protocol events, identifiers, and relay messages, built on Zod v4 with optional signature verification.
 
 ## Bridges and Gateways
 


### PR DESCRIPTION
Adds [zod-nostr](https://github.com/akiomik/zod-nostr) to the Libraries section.

zod-nostr is a TypeScript library that provides Zod schemas and codecs for the Nostr protocol, built on Zod v4.
It covers event structures, bech32 identifiers, relay messages, and authentication messages across multiple NIPs, supports both the classic Zod and Zod/mini APIs, and offers optional signature verification.