### PR TITLE
Add curated repos to nostr directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ nostr.net services [start.nostr.net](https://start.nostr.net) || [relay.nostr.ne
 - [Marmot Protocol](https://github.com/marmot-protocol/marmot)![stars](https://img.shields.io/github/stars/marmot-protocol/marmot.svg?style=social) - A messaging protocol specification for efficient end-to-end encrypted group messaging using Nostr's decentralized identity & relay network combined with the MLS Protocol.
 - [keytr](https://github.com/sovITxyz/keytr)![stars](https://img.shields.io/github/stars/sovITxyz/keytr.svg?style=social) - KEYS TRANSMITTED OVER RELAYS Nostr login protocol using WebAuthn passkeys to encrypt and distribute nsec keys
 - [gozzip](https://github.com/gozzip-protocol/gozzip)![stars](https://img.shields.io/github/stars/gozzip-protocol/gozzip.svg?style=social) - An open, censorship-resistant protocol for social media and messaging. Inherits Nostr's proven primitives — secp256k1 identity, signed events, relay transport — and adds a storage and retrieval layer where users own their data
+- [chat29](https://github.com/fiatjaf/chat29)![stars](https://img.shields.io/github/stars/fiatjaf/chat29.svg?style=social) - simple web chat client for nip-29
 
 ## Relays
 
@@ -768,6 +769,7 @@ Websites with lists of relays and their performance/health:
 - [TENEX](https://github.com/tenex-chat/tenex)![stars](https://img.shields.io/github/stars/tenex-chat/tenex.svg?style=social) - AI agent orchestration platform on Nostr.
 - [TollGate](https://tollgate.me) - Pay-per-use Wi-Fi access using Nostr and Lightning.
 - [Yondar](https://go.yondar.me) - Location-based social discovery on Nostr.
+- [nostr.com](https://github.com/fiatjaf/nostr.com)![stars](https://img.shields.io/github/stars/fiatjaf/nostr.com.svg?style=social) - Nostr twitter client
 
 ## NIP-05 identity services
 

--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ Websites with lists of relays and their performance/health:
 - [nospeak](https://github.com/psic4t/nospeak)![stars](https://img.shields.io/github/stars/psic4t/nospeak.svg?style=social) - A NIP-17 compliant chat client for secure, private messaging over Nostr
 - [Nosky](https://github.com/KotlinGeekDev/Nosky)![stars](https://img.shields.io/github/stars/KotlinGeekDev/Nosky.svg?style=social) - A native Android client for Nostr. Still in development
 - [nostr console](https://github.com/vishalxl/nostr_console)![stars](https://img.shields.io/github/stars/vishalxl/nostr_console.svg?style=social) - a nostr command line client written in Dart. Binaries available for Windows, Linux, and macOS
+- [nostr.com](https://github.com/fiatjaf/nostr.com)![stars](https://img.shields.io/github/stars/fiatjaf/nostr.com.svg?style=social) - Nostr twitter client
 - [Nostr Read Only Client](https://github.com/delirehberi/nostr-ro-client/)![stars](https://img.shields.io/github/stars/delirehberi/nostr-ro-client.svg?style=social) - simple cloudflare worker to serve a single user's nostr content (kind:1) as web page preview: nostr.emre.xyz
 - [Nostria](https://nostria.app) - Web, Desktop, iOS and Android app for Nostr, easy to get started for new users. Multiple feeds with multiple columns, Live Streams, Articles, Media Library, Video recording, Audio recording. 
 - [Hugo2Nostr](https://github.com/delirehberi/hugo2nostr)![stars](https://img.shields.io/github/stars/delirehberi/hugo2nostr.svg?style=social) - Sync your hugo blog with nostr network. The tool have scripts to sync contents. 
@@ -769,7 +770,6 @@ Websites with lists of relays and their performance/health:
 - [TENEX](https://github.com/tenex-chat/tenex)![stars](https://img.shields.io/github/stars/tenex-chat/tenex.svg?style=social) - AI agent orchestration platform on Nostr.
 - [TollGate](https://tollgate.me) - Pay-per-use Wi-Fi access using Nostr and Lightning.
 - [Yondar](https://go.yondar.me) - Location-based social discovery on Nostr.
-- [nostr.com](https://github.com/fiatjaf/nostr.com)![stars](https://img.shields.io/github/stars/fiatjaf/nostr.com.svg?style=social) - Nostr twitter client
 
 ## NIP-05 identity services
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ nostr.net services [start.nostr.net](https://start.nostr.net) || [relay.nostr.ne
 - [Marmot Protocol](https://github.com/marmot-protocol/marmot)![stars](https://img.shields.io/github/stars/marmot-protocol/marmot.svg?style=social) - A messaging protocol specification for efficient end-to-end encrypted group messaging using Nostr's decentralized identity & relay network combined with the MLS Protocol.
 - [keytr](https://github.com/sovITxyz/keytr)![stars](https://img.shields.io/github/stars/sovITxyz/keytr.svg?style=social) - KEYS TRANSMITTED OVER RELAYS Nostr login protocol using WebAuthn passkeys to encrypt and distribute nsec keys
 - [gozzip](https://github.com/gozzip-protocol/gozzip)![stars](https://img.shields.io/github/stars/gozzip-protocol/gozzip.svg?style=social) - An open, censorship-resistant protocol for social media and messaging. Inherits Nostr's proven primitives — secp256k1 identity, signed events, relay transport — and adds a storage and retrieval layer where users own their data
-- [chat29](https://github.com/fiatjaf/chat29)![stars](https://img.shields.io/github/stars/fiatjaf/chat29.svg?style=social) - simple web chat client for nip-29
 
 ## Relays
 
@@ -229,6 +228,7 @@ Websites with lists of relays and their performance/health:
   - [dabena.github.io/Brezn/](https://dabena.github.io/Brezn/) - live instance
 - [caracal](https://gitlab.com/cipres/caracal) - Nostr client for the [Gemini](https://geminiprotocol.net/) protocol. Use Nostr from your Gemini browser! [nsite](https://npub1vsgkdknxzhj9853gmpz5hkvr5a9zysqcnaphwfcex5k0te776ckq8ucxqx.nsite.lol/)
 - [cassette](https://cassette.cafe) - Portable WASM relays with standardized interface/bindings.
+- [chat29](https://github.com/fiatjaf/chat29)![stars](https://img.shields.io/github/stars/fiatjaf/chat29.svg?style=social) - simple web chat client for nip-29
 - [Clawstr](https://github.com/clawstr/clawstr)![stars](https://img.shields.io/github/stars/clawstr/clawstr.svg?style=social) - Social network for AI agents on Nostr [clawstr.com](https://clawstr.com/)
 - [+Chorus](https://github.com/andotherstuff/chorus/)![stars] - +chorus is a simple space for communities to gather, share, and support each other.
 - [connect4](https://github.com/stutxo/connect4xyz)![stars](https://img.shields.io/github/stars/stutxo/connect4xyz.svg?style=social) - connect 4 over nostr


### PR DESCRIPTION
## Curated Repository Additions

Added 2 repository candidate(s), placed into matching README sections rather than appended as a bulk dump.

- fiatjaf/nostr.com
- fiatjaf/chat29

## Safety checks
- Entries are inserted into existing sections only.
- Bulk PRs over 12 repositories are refused by the helper script.
- Unclassified repositories are skipped instead of being appended to the end.

---
*Auto-discovered by the awesome-directory-updater bot; conservatively categorized by create-directory-pr.py.*