### PR TITLE
Add curated repos to nostr directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ nostr.net services [start.nostr.net](https://start.nostr.net) || [relay.nostr.ne
 - [coracle.social](https://coracle.social/)
 - [YakiHonne](https://yakihonne.com)
 - [Ditto](https://ditto.pub)
-- [inference-provider-api](https://github.com/fiatjaf/inference-provider-api)![stars](https://img.shields.io/github/stars/fiatjaf/inference-provider-api.svg?style=social) - The Inference Provider API (IPA) is a proposed browser standard that allows web applications to request AI inference from a user-approved browser extension without ever accessing API keys.
 
 ### Other
 - [Zapstore](https://zapstore.dev/) - Web of trust based app store 
@@ -150,7 +149,6 @@ Websites with lists of relays and their performance/health:
 - [nostr.watch](https://nostr.watch)![stars](https://img.shields.io/github/stars/sandwichfarm/nostr-watch.svg?style=social) - real-time checking of the status of some known relays.
 - [relays.xport.top](https://relays.xport.top) - relays list sortable by ping, activity, etc.
 - [trustedrelays.xyz](https://trustedrelays.xyz) - relays list with trust scores for known relays using Trusted Relay Assertions.
-- [inference-bridge](https://github.com/fiatjaf/inference-bridge)![stars](https://img.shields.io/github/stars/fiatjaf/inference-bridge.svg?style=social) - Official reference implementation of the Inference Provider API proposal.
 
 ## Clients
 ### Long form clients
@@ -760,6 +758,8 @@ Websites with lists of relays and their performance/health:
 - [Holy Fit](https://git.vanderwarker.family/wellbeing/holyfit-android) - Fitness tracking client publishing to Nostr.
 - [HyperNote](https://github.com/futurepaul/hypernote)![stars](https://img.shields.io/github/stars/futurepaul/hypernote.svg?style=social) - Hypermedia format for interactive Nostr notes.
 - [Innpub](https://github.com/futurepaul/innpub)![stars](https://img.shields.io/github/stars/futurepaul/innpub.svg?style=social) - Local pub/community discovery on Nostr.
+- [inference-bridge](https://github.com/fiatjaf/inference-bridge)![stars](https://img.shields.io/github/stars/fiatjaf/inference-bridge.svg?style=social) - Official reference implementation of the Inference Provider API proposal.
+- [inference-provider-api](https://github.com/fiatjaf/inference-provider-api)![stars](https://img.shields.io/github/stars/fiatjaf/inference-provider-api.svg?style=social) - The Inference Provider API (IPA) is a proposed browser standard that allows web applications to request AI inference from a user-approved browser extension without ever accessing API keys.
 - [Mapnolia](https://github.com/zeSchlausKwab/mapnolia)![stars](https://img.shields.io/github/stars/zeSchlausKwab/mapnolia.svg?style=social) - Map-based Nostr client.
 - [NEET](https://github.com/justinmoon/neet-native)![stars](https://img.shields.io/github/stars/justinmoon/neet-native.svg?style=social) - Native Nostr application toolkit.
 - [Nostrocket](https://github.com/nostrocket/oxygen)![stars](https://img.shields.io/github/stars/nostrocket/oxygen.svg?style=social) - Decentralized project management on Nostr.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ nostr.net services [start.nostr.net](https://start.nostr.net) || [relay.nostr.ne
 - [coracle.social](https://coracle.social/)
 - [YakiHonne](https://yakihonne.com)
 - [Ditto](https://ditto.pub)
+- [inference-provider-api](https://github.com/fiatjaf/inference-provider-api)![stars](https://img.shields.io/github/stars/fiatjaf/inference-provider-api.svg?style=social) - The Inference Provider API (IPA) is a proposed browser standard that allows web applications to request AI inference from a user-approved browser extension without ever accessing API keys.
 
 ### Other
 - [Zapstore](https://zapstore.dev/) - Web of trust based app store 
@@ -149,6 +150,7 @@ Websites with lists of relays and their performance/health:
 - [nostr.watch](https://nostr.watch)![stars](https://img.shields.io/github/stars/sandwichfarm/nostr-watch.svg?style=social) - real-time checking of the status of some known relays.
 - [relays.xport.top](https://relays.xport.top) - relays list sortable by ping, activity, etc.
 - [trustedrelays.xyz](https://trustedrelays.xyz) - relays list with trust scores for known relays using Trusted Relay Assertions.
+- [inference-bridge](https://github.com/fiatjaf/inference-bridge)![stars](https://img.shields.io/github/stars/fiatjaf/inference-bridge.svg?style=social) - Official reference implementation of the Inference Provider API proposal.
 
 ## Clients
 ### Long form clients


### PR DESCRIPTION
## Curated Repository Additions

Added 3 repository candidate(s), placed into matching README sections rather than appended as a bulk dump.

- fiatjaf/inference-bridge
- fiatjaf/inference-provider-api
- cameri/skills

## Safety checks
- Entries are inserted into existing sections only.
- Bulk PRs over 12 repositories are refused by the helper script.
- Unclassified repositories are skipped instead of being appended to the end.

---
*Auto-discovered by the awesome-directory-updater bot; conservatively categorized by create-directory-pr.py.*