### PR TITLE
Add Galaxy Mind to Other links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1063,6 +1063,7 @@ Outside of nostr itself, you find the community on:
 
 - [awesome-nostr-japan](https://github.com/nostr-jp/awesome-nostr-japan)![stars](https://img.shields.io/github/stars/nostr-jp/awesome-nostr-japan.svg?style=social) - awesome nostr japan
 - [awesome-nostr-possibilities](https://github.com/orthzar/awesome-nostr-possibilities)![stars](https://img.shields.io/github/stars/orthzar/awesome-nostr-possibilities.svg?style=social) - Nostr will fail if it stays just another social media protocol. This repo lists ideas for non-social-media applications.
+- [Galaxy Mind](https://galaxymind.space/) - Directory of merchants that accept bitcoin, including 46 Nostr-native vendors listed by npub or NIP-05.
 - [inosta api](https://github.com/johnongit/INOSTA-Nostr-Img-Service)![stars](https://img.shields.io/github/stars/johnongit/INOSTA-Nostr-Img-Service.svg?style=social) - Expensive Image Hosting Service
   - [api.inosta.cc](https://api.inosta.cc) - Backend live instance
   - [inosta.cc](https://inosta.cc) - Demonstrator live instance


### PR DESCRIPTION
Adds one line to `## Other links`, alphabetically placed.

Galaxy Mind is a directory of merchants that accept bitcoin. 46 of its 128 listings are Nostr-native and are addressed by npub, nprofile or NIP-05, so a Nostr user can reach the merchant's profile directly from the listing.

I put it in Other links rather than Nostr Marketplace clients because it is not marketplace software. It does not host listings or process orders. It indexes merchants across platforms and links out to their profiles, so it sits alongside the other reference links in that section.

Every listing is confirmed by a person before it appears and shows the UTC date it was last confirmed. There is a public JSON API at https://galaxymind.space/api/vendors.json if it is useful to anyone building on this list.

Disclosure: I run it.