### PR TITLE
Add Aeon to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -588,6 +588,7 @@ Websites with lists of relays and their performance/health:
 
 ## Tools
 
+- [Aeon](https://github.com/aeonfun/aeon)![stars](https://img.shields.io/github/stars/aeonfun/aeon.svg?style=social) - Autonomous AI agent framework that publishes signed notes to Nostr relays as an outbound channel.
 - [Amethyst crawler](https://crawler.amethyst.social/) - Find and broadcast nostr events
 - [anonroom](https://github.com/vinliao/anonroom)![stars](https://img.shields.io/github/stars/vinliao/anonroom.svg?style=social) - anonymous chat room inside nostr
 - [Bech32 for Nostr](https://nostr.xport.top/bech32-for-nostr/) - bech32 Nostr converter.


### PR DESCRIPTION
Adding [Aeon](https://github.com/aeonfun/aeon) under **Tools**.

Aeon is an open-source (MIT) autonomous AI agent framework. Nostr is one of its outbound channels: it publishes signed notes to Nostr relays (specifically Block's Buzz relay via a signed publish), so agent runs can broadcast to Nostr the same way they report to Telegram/Discord/Slack. This fits alongside the existing agent/Nostr tools in this section such as bray and Gravity Swarm MCP.

- Repo: https://github.com/aeonfun/aeon
- Open source (MIT), actively maintained (daily commits).
- Placed alphabetically at the top of the Tools section with the stars badge, single entry, format matches the surrounding lines.

Disclosure: I contribute to this project.