### PR TITLE
Update LiberMedia and Makoré — live URLs, zap links, Android+Web

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,6 @@ of the public instances.
 Websites with lists of relays and their performance/health:
 - [georelays](https://github.com/permissionlesstech/georelays)![stars](https://img.shields.io/github/stars/permissionlesstech/georelays.svg?style=social) - A collection of nostr relays and their estimated geographic locations for discovering nearby relays.
 - [relay.nostr.net](wss://relay.nostr.net) - relay run by nostr.net 
-- [relay.libernet.app](wss://relay.libernet.app) - open public Nostr relay by LiberNet, operated from Israel [⚡ zap](https://nostr.net/grant/?zap=barak@blink.sv)
 - [nostr.info](https://nostr.info/relays/) - real-time checking of the status of some known relays.
 - [nostr.watch](https://nostr.watch)![stars](https://img.shields.io/github/stars/sandwichfarm/nostr-watch.svg?style=social) - real-time checking of the status of some known relays.
 - [relays.xport.top](https://relays.xport.top) - relays list sortable by ping, activity, etc.
@@ -207,8 +206,8 @@ Websites with lists of relays and their performance/health:
 - [Pika](https://github.com/sledtools/pika)![stars](https://img.shields.io/github/stars/sledtools/pika.svg?style=social) -  End-to-end encrypted messaging for iOS, Android, and Desktop, built on MLS over Nostr.
 - [Zemzeme](https://github.com/whisperbit-labs/zemzeme-android)![stars](https://img.shields.io/github/stars/whisperbit-labs/zemzeme-android.svg?style=social) - Private, serverless messaging for Android — offline Bluetooth mesh, peer-to-peer, and Nostr relay. No accounts, no internet required
 - [VaultChat](https://vaultchat.pro) - Encrypted Android messenger built on Nostr. NIP-44 v2, groups, Decoy PIN. No phone number, no email, no server.
-- [LiberMedia](https://media.libernet.app)![stars](https://img.shields.io/github/stars/lucianocasalunga/libermedia-twa.svg?style=social) - Open-source Nostr social network with Bitcoin/Lightning zaps, DMs, media and groups. Android + Web. [⚡ zap](https://nostr.net/grant/?zap=barak@blink.sv)
-- [Makoré](https://makore.libernet.app)![stars](https://img.shields.io/github/stars/lucianocasalunga/makore-twa.svg?style=social) - End-to-end encrypted Nostr messenger with NIP-17/NIP-44 DMs, group chats and Bitcoin/Lightning gifts. Android + Web. [⚡ zap](https://nostr.net/grant/?zap=barak@blink.sv)
+- [LiberMedia](https://media.libernet.app)![stars](https://img.shields.io/github/stars/lucianocasalunga/libermedia-twa.svg?style=social) - Android + Web client with zaps, DMs, media and groups. [⚡ zap](https://nostr.net/grant/?zap=barak@blink.sv)
+- [Makoré](https://makore.libernet.app)![stars](https://img.shields.io/github/stars/lucianocasalunga/makore-twa.svg?style=social) - End-to-end encrypted messenger with NIP-17/NIP-44 DMs, group chats and zaps. Android + Web. [⚡ zap](https://nostr.net/grant/?zap=barak@blink.sv)
 
 ### Other  
 - [Agora](https://agorasocial.app) ![stars](https://img.shields.io/github/stars/ghobs91/agora.svg?style=social) - Follow your favorite topics in nostr-verse (and even posts from Mastodon, Reddit, Bluesky, and Twitter)

--- a/README.md
+++ b/README.md
@@ -792,7 +792,6 @@ Websites with lists of relays and their performance/health:
  - [Iris Video](https://video.iris.to) - Videos over Nostr & blossom
  - [Iris Files](https://files.iris.to) - Blossom based filesystem and explorer
 - [jellyfish.land](https://jellyfish.land/nip05) - Nostr NIP-05 handles on @nostr.eco domain with WoT protection
-- [LiberMedia](https://media.libernet.app/editar-perfil) - Free NIP-05 ID included with every account on the LiberMedia social network. [⚡ zap](https://nostr.net/grant/?zap=barak@blink.sv)
 - [lifpay.me](https://lifpay.me) - Lightning wallet with NIP-05 ID registration service.
 - [nanostr](https://github.com/xbol0/nanostr)![stars](https://img.shields.io/github/stars/xbol0/nanostr?style=social) - A NIP-05 name server written in Deno.
 - [Nostr-Check.com](https://nostr-check.com) - A free NIP-05 ID registration service.

--- a/README.md
+++ b/README.md
@@ -792,6 +792,7 @@ Websites with lists of relays and their performance/health:
  - [Iris Video](https://video.iris.to) - Videos over Nostr & blossom
  - [Iris Files](https://files.iris.to) - Blossom based filesystem and explorer
 - [jellyfish.land](https://jellyfish.land/nip05) - Nostr NIP-05 handles on @nostr.eco domain with WoT protection
+- [LiberMedia](https://media.libernet.app/editar-perfil) - Free NIP-05 ID included with every account on the LiberMedia social network. [⚡ zap](https://nostr.net/grant/?zap=barak@blink.sv)
 - [lifpay.me](https://lifpay.me) - Lightning wallet with NIP-05 ID registration service.
 - [nanostr](https://github.com/xbol0/nanostr)![stars](https://img.shields.io/github/stars/xbol0/nanostr?style=social) - A NIP-05 name server written in Deno.
 - [Nostr-Check.com](https://nostr-check.com) - A free NIP-05 ID registration service.

--- a/README.md
+++ b/README.md
@@ -206,8 +206,8 @@ Websites with lists of relays and their performance/health:
 - [Pika](https://github.com/sledtools/pika)![stars](https://img.shields.io/github/stars/sledtools/pika.svg?style=social) -  End-to-end encrypted messaging for iOS, Android, and Desktop, built on MLS over Nostr.
 - [Zemzeme](https://github.com/whisperbit-labs/zemzeme-android)![stars](https://img.shields.io/github/stars/whisperbit-labs/zemzeme-android.svg?style=social) - Private, serverless messaging for Android — offline Bluetooth mesh, peer-to-peer, and Nostr relay. No accounts, no internet required
 - [VaultChat](https://vaultchat.pro) - Encrypted Android messenger built on Nostr. NIP-44 v2, groups, Decoy PIN. No phone number, no email, no server.
-- [LiberMedia](https://github.com/lucianocasalunga/libermedia-twa)![stars](https://img.shields.io/github/stars/lucianocasalunga/libermedia-twa.svg?style=social) - Social Nostr client for Android with Bitcoin/Lightning zaps, groups and DMs. 
-- [Makoré](https://github.com/lucianocasalunga/makore-twa)![stars](https://img.shields.io/github/stars/lucianocasalunga/makore-twa.svg?style=social) - End-to-end encrypted Nostr messenger for Android with NIP-17/NIP-44 DMs, E2E groups, ephemeral rooms and Bitcoin/Lightning gifts.
+- [LiberMedia](https://media.libernet.app)![stars](https://img.shields.io/github/stars/lucianocasalunga/libermedia-twa.svg?style=social) - Open-source Nostr social network with Bitcoin/Lightning zaps, DMs, media and groups. Android + Web. [⚡ zap](https://nostr.net/grant/?zap=barak@blink.sv)
+- [Makoré](https://makore.libernet.app)![stars](https://img.shields.io/github/stars/lucianocasalunga/makore-twa.svg?style=social) - End-to-end encrypted Nostr messenger with NIP-17/NIP-44 DMs, group chats and Bitcoin/Lightning gifts. Android + Web. [⚡ zap](https://nostr.net/grant/?zap=barak@blink.sv)
 
 ### Other  
 - [Agora](https://agorasocial.app) ![stars](https://img.shields.io/github/stars/ghobs91/agora.svg?style=social) - Follow your favorite topics in nostr-verse (and even posts from Mastodon, Reddit, Bluesky, and Twitter)

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ of the public instances.
 Websites with lists of relays and their performance/health:
 - [georelays](https://github.com/permissionlesstech/georelays)![stars](https://img.shields.io/github/stars/permissionlesstech/georelays.svg?style=social) - A collection of nostr relays and their estimated geographic locations for discovering nearby relays.
 - [relay.nostr.net](wss://relay.nostr.net) - relay run by nostr.net 
+- [relay.libernet.app](wss://relay.libernet.app) - open public Nostr relay by LiberNet, operated from Israel [⚡ zap](https://nostr.net/grant/?zap=barak@blink.sv)
 - [nostr.info](https://nostr.info/relays/) - real-time checking of the status of some known relays.
 - [nostr.watch](https://nostr.watch)![stars](https://img.shields.io/github/stars/sandwichfarm/nostr-watch.svg?style=social) - real-time checking of the status of some known relays.
 - [relays.xport.top](https://relays.xport.top) - relays list sortable by ping, activity, etc.


### PR DESCRIPTION
Updates our two existing entries with:

- **URLs**: GitHub repo → live app URLs (`media.libernet.app` and `makore.libernet.app`)
- **Zap links**: added `[⚡ zap]` for both apps
- **Description**: clarified "Android + Web" (both are PWA + APK, not Android-only)
- **Wording**: improved descriptions to better reflect what each app does