### PR TITLE
Improve gupt entry in Clients > Other

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,9 @@ Websites with lists of relays and their performance/health:
 - [gossip](https://github.com/mikedilger/gossip)![stars](https://img.shields.io/github/stars/mikedilger/gossip.svg?style=social) - A desktop client in rust presented with egui
 - [Groups](https://github.com/max21dev/groups)![stars](https://img.shields.io/github/stars/max21dev/groups.svg?style=social) - NIP-29 Group Chat Web Client.
   - Live Instance: [groups.nip29.com](https://groups.nip29.com)
-- [gupt](https://gupt.app) - Instant Nostr chat with zero config — no relays to set up, no upload servers. Supports video calls, audio calls, screen sharing, and private group chats.
+- [GUPT](https://github.com/besoeasy/gupt)![stars](https://img.shields.io/github/stars/besoeasy/gupt.svg?style=social) - Anonymous Nostr messenger & privacy suite: E2E chat, P2P video/audio calls, screen sharing, encrypted passwords/notes/bookmarks. No phone, email or accounts.
+  - [gupt.app](https://gupt.app/) - live instance
+  - [Flatpak](https://flathub.org/en/apps/com.besoeasy.gupt) - Linux desktop app
 - [Hook Cafe](https://github.com/kuba-04/hook.cafe)![stars](https://img.shields.io/github/stars/kuba-04/hook.cafe.svg?style=social) - A social app helping people to meet in real life
   -  [hook.cafe](https://hook.cafe) - live instance
 - [get-tao.app](https://github.com/smolgrrr/TAO)![stars](https://img.shields.io/github/stars/smolgrrr/TAO.svg?style=social) Anonymous-first client with PoW notes

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ Websites with lists of relays and their performance/health:
 - [gossip](https://github.com/mikedilger/gossip)![stars](https://img.shields.io/github/stars/mikedilger/gossip.svg?style=social) - A desktop client in rust presented with egui
 - [Groups](https://github.com/max21dev/groups)![stars](https://img.shields.io/github/stars/max21dev/groups.svg?style=social) - NIP-29 Group Chat Web Client.
   - Live Instance: [groups.nip29.com](https://groups.nip29.com)
-- [GUPT](https://github.com/besoeasy/gupt)![stars](https://img.shields.io/github/stars/besoeasy/gupt.svg?style=social) - Anonymous Nostr messenger & privacy suite: E2E chat, P2P video/audio calls, screen sharing, encrypted passwords/notes/bookmarks. No phone, email or accounts.
+- [GUPT](https://github.com/besoeasy/gupt)![stars](https://img.shields.io/github/stars/besoeasy/gupt.svg?style=social) - Anonymous Nostr messenger & privacy suite: E2E chat, P2P video/audio calls, screen sharing, encrypted passwords/notes/bookmarks.
   - [gupt.app](https://gupt.app/) - live instance
   - [Flatpak](https://flathub.org/en/apps/com.besoeasy.gupt) - Linux desktop app
 - [Hook Cafe](https://github.com/kuba-04/hook.cafe)![stars](https://img.shields.io/github/stars/kuba-04/hook.cafe.svg?style=social) - A social app helping people to meet in real life


### PR DESCRIPTION
Updates the existing `gupt` entry under **Clients → Other**:

- Link the GitHub repo instead of only gupt.app (matching neighboring entries)
- Add the standard stars badge
- Broaden the description to cover the full suite: E2E chat, P2P video/audio calls, screen sharing, encrypted passwords/notes/bookmarks
- Add live instance ([gupt.app](https://gupt.app)) and [Flatpak](https://flathub.org/en/apps/com.besoeasy.gupt) sub-bullets

Per the contributing guide.